### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"
@@ -37,6 +40,8 @@ jobs:
       name: Publish for ${{ matrix.os }}
       runs-on: ${{ matrix.os }}
       if: github.event_name == 'push'
+      permissions:
+        contents: write
       strategy:
         matrix:
           include:


### PR DESCRIPTION
Potential fix for [https://github.com/tsturzenegger/tcpperf/security/code-scanning/2](https://github.com/tsturzenegger/tcpperf/security/code-scanning/2)

In general, the fix is to explicitly set least-privilege `permissions` for the workflow or specific jobs instead of relying on repository defaults. Jobs that only read code (build/test) can use `contents: read`, while jobs that must modify releases or other contents need `contents: write` but typically nothing more.

For this workflow, the best minimal change without altering existing behavior is:
- Add a top-level `permissions:` block with `contents: read`, which safely covers the `build` job (it only checks out code and builds/tests).
- Override permissions in the `publish` job to give it `contents: write`, which is required for uploading release assets, while keeping all other scopes at their default `none`.

Concretely:
- In `.github/workflows/rust.yml`, insert a root-level `permissions:` block after the `on:` section setting `contents: read`.
- In the `publish` job definition, add a `permissions:` block under `publish:` (aligned with `name:` and `runs-on:`) setting `contents: write`.

No new imports or external libraries are needed; this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
